### PR TITLE
[Do not merge] Update socket fallback-x11

### DIFF
--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -170,7 +170,7 @@
 			[
 				{
 					"type":		"git",
-					"commit":	"3658363bc7b1f99dcae484472eb054dff57af797", 
+					"commit":	"50ea91956570186e337fc95bafe1cdcfdbc3a948", 
 					"url": 		"https://github.com/shun2wang/jasp-desktop.git"
 				}
 			]

--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -170,8 +170,8 @@
 			[
 				{
 					"type":		"git",
-					"commit":	"b8d62a717272d574f8966fd953a20608adc7895b", 
-					"url": 		"https://github.com/jasp-stats/jasp-desktop.git"
+					"commit":	"3658363bc7b1f99dcae484472eb054dff57af797", 
+					"url": 		"https://github.com/shun2wang/jasp-desktop.git"
 				}
 			]
 		}

--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -7,7 +7,7 @@
 	"base-version":			"6.4",
 	"command": 			"org.jaspstats.JASP",
 	"finish-args": [
-		"--socket=x11",
+		"--socket=fallback-x11",
 		"--socket=wayland",
 		"--share=ipc",
 		"--share=network",


### PR DESCRIPTION
refer to https://docs.flatpak.org/en/latest/sandbox-permissions.html#standard-permissions, trying to remove the gnome unsafe rating with legacy windowing system like this:
![image](https://user-images.githubusercontent.com/818622/140544387-aece71bd-6302-4e14-ac08-e9f978326fc3.png)

any one can try this parameter and close it when release?