### PR TITLE
update freexl to jasp patch version 2.0.99.cci.20250526

### DIFF
--- a/deps/freexl.json
+++ b/deps/freexl.json
@@ -9,8 +9,8 @@
     "sources":[
         {
             "type": 	"archive",
-            "url": 		"https://static.jasp-stats.org/freexl-2.0.0.tar.gz",
-            "sha256":   "fed8f3a5743bdbc2c9965145a52a54578fa99dc92c07eb56bd57390a72e9319f"
+            "url": 		"https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz",
+            "sha256":   "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"
         }
     ]
 }

--- a/deps/freexl.json
+++ b/deps/freexl.json
@@ -9,8 +9,8 @@
     "sources":[
         {
             "type": 	"archive",
-            "url": 		"https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz",
-            "sha256":   "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"
+            "url": 		"https://github.com/jasp-stats/freexl/archive/3c849e2424ac15dc5417970fbb36ca5b9a191983.tar.gz",
+            "sha256":   "8983fe8e7c0807fb916b7c3d385145728b3e161fa2b6e435e6acf92ed6c77f11"
         }
     ]
 }

--- a/deps/freexl.json
+++ b/deps/freexl.json
@@ -2,6 +2,7 @@
     "name": 		"freexl",
     "buildsystem": 	"simple",
     "build-commands":[
+        "autoreconf -vfi",
         "./configure --prefix /app",
         "make",
         "make install" 
@@ -9,8 +10,8 @@
     "sources":[
         {
             "type": 	"archive",
-            "url": 		"https://github.com/jasp-stats/freexl/archive/3c849e2424ac15dc5417970fbb36ca5b9a191983.tar.gz",
-            "sha256":   "8983fe8e7c0807fb916b7c3d385145728b3e161fa2b6e435e6acf92ed6c77f11"
+            "url": 		"https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz",
+            "sha256":   "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"
         }
     ]
 }

--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -164,7 +164,7 @@
                 {
                    "type": "git",
                    "commit": "8e59b28f375b649464330d5032ce337e0fee7cff",
-                   "url": "https://github.com/RensDofferhoff/jasp-desktop.git"
+                   "url": "https://github.com/jasp-stats/jasp-desktop.git"
                 }
             ],
             "post-install": ["chmod -R u+w ./"]

--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -163,7 +163,7 @@
             "sources": [
                 {
                    "type": "git",
-                   "commit": "50d046a6705095a8d4218132d6a5a2ca58dc91c5",
+                   "commit": "8e59b28f375b649464330d5032ce337e0fee7cff",
                    "url": "https://github.com/RensDofferhoff/jasp-desktop.git"
                 }
             ],


### PR DESCRIPTION
Address: https://github.com/jasp-stats/INTERNAL-jasp/issues/2848