### PR TITLE
use version that start engines when there are none

### DIFF
--- a/org.jaspstats.JASP.json
+++ b/org.jaspstats.JASP.json
@@ -164,7 +164,7 @@
             "sources": [
                 {
                    "type": "git",
-                   "commit": "9e139838b6541ee715b84a257172a6e513697500",
+                   "commit": "f918c78a4188ad2b8b06a9976a8ecf6a78c7d4db",
                    "url": "https://github.com/jasp-stats/jasp-desktop.git"
                 }
             ],


### PR DESCRIPTION
use jasp-desktop@f918c78a4188ad2b8b06a9976a8ecf6a78c7d4db